### PR TITLE
Allowing for a comma delimited list of targets to be passed in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.398</version>
+    <version>1.518</version>
   </parent>
   
   <artifactId>nant</artifactId>

--- a/src/main/java/hudson/plugins/nant/NantBuilder.java
+++ b/src/main/java/hudson/plugins/nant/NantBuilder.java
@@ -150,9 +150,9 @@ public class NantBuilder extends Builder {
         // add the property declarations to the command line
         args.addKeyValuePairsFromPropertyString("-D:", properties, vr);
         
-        // Remove all tabs, carriage returns, and newlines and replace them with
+        // Remove all commas, tabs, carriage returns, and newlines and replace them with
         // spaces, so that we can add them as parameters to the executable
-        String normalizedTarget = targets.replaceAll("[\t\r\n]+"," ");
+        String normalizedTarget = targets.replaceAll("[,\t\r\n]+"," ");
         if(normalizedTarget.trim().length()>0)
         	args.addTokenized(normalizedTarget);
         

--- a/src/main/webapp/help-Targets.html
+++ b/src/main/webapp/help-Targets.html
@@ -1,6 +1,6 @@
 <div>
   <p>
-    This is a whitespace separated list of targets to run.  The targets should be 
+    This is a whitespace separated OR comma delimited list of targets to run.  The targets should be 
     specified in your Nant build file.
   </p>
 </div>


### PR DESCRIPTION
Would be nice to have this plugin accept Jenkins job build parameters from other plugins.  In particular the Extended Choice Parameter Plugin, which only allows for a comma delimited list to be passed into its multi-select parameter type.  I would like the multi-select list to be NAnt targets, but trying to use these two plugins together requires two additional build steps and the use of another plugin to massage the build parameter into a whitespace separated list.
